### PR TITLE
Prevent NullPointerException on Android

### DIFF
--- a/src/android/WebShareReceiver.java
+++ b/src/android/WebShareReceiver.java
@@ -10,7 +10,9 @@ public class WebShareReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        lastChosenComponent = (ComponentName)intent.getExtras().get(Intent.EXTRA_CHOSEN_COMPONENT);
+        if (intent.getExtras() != null) {
+            lastChosenComponent = (ComponentName) intent.getExtras().get(Intent.EXTRA_CHOSEN_COMPONENT);
+        }
     }
 
     public static void resetChosenComponent() {


### PR DESCRIPTION
Added null check to prevent a _NullPointerException_ (which causes the app to crash) on Android devices.